### PR TITLE
DOM reimplementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ pkg
 tags
 .DS_Store
 a11y.rb
+node_modules
+lib/bbc/a11y/js/bundle.js

--- a/bbc-a11y.gemspec
+++ b/bbc-a11y.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_dependency 'capybara'
+  s.add_dependency 'phantomjs'
+  s.add_dependency 'poltergeist'
   s.add_dependency 'colorize'
 
   s.add_development_dependency 'rspec',  '~> 3.0'

--- a/bbc-a11y.gemspec
+++ b/bbc-a11y.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'colorize'
 
   s.add_development_dependency 'rspec',  '~> 3.0'
-  s.add_development_dependency 'aruba'
+  s.add_development_dependency 'aruba', '~> 0.9'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'cucumber'

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - bundle exec rake

--- a/features/check_standards/focusable_controls.feature
+++ b/features/check_standards/focusable_controls.feature
@@ -42,7 +42,7 @@ Feature: Focusable Controls
           <li><a href="#entertainmenttab">Entertainment</a></li>
       </ul>
       """
-    When I validate the anchor hrefs standards
+    When I validate the anchors must have hrefs standards
     Then it passes
 
   Scenario: Some anchor tags do not have href attributes
@@ -54,7 +54,7 @@ Feature: Focusable Controls
           <li><a>Entertainment</a></li>
       </ul>
       """
-    When I validate the anchor hrefs standards
+    When I validate the anchors must have hrefs standards
     Then it fails with the message:
       """
       Anchor has no href attribute: /html/body/ul/li[1]/a

--- a/features/check_standards/focusable_controls.feature
+++ b/features/check_standards/focusable_controls.feature
@@ -42,7 +42,7 @@ Feature: Focusable Controls
           <li><a href="#entertainmenttab">Entertainment</a></li>
       </ul>
       """
-    When I validate the anchors must have hrefs standards
+    When I validate the "anchors must have hrefs" standard
     Then it passes
 
   Scenario: Some anchor tags do not have href attributes
@@ -54,7 +54,7 @@ Feature: Focusable Controls
           <li><a>Entertainment</a></li>
       </ul>
       """
-    When I validate the anchors must have hrefs standards
+    When I validate the "anchors must have hrefs" standard
     Then it fails with the message:
       """
       Anchor has no href attribute: /html/body/ul/li[1]/a

--- a/features/check_standards/form_interactions.feature
+++ b/features/check_standards/form_interactions.feature
@@ -27,7 +27,7 @@ Feature: Form Interactions
         <input type="submit" value="Search">
       </form>
       """
-    When I validate the form submit buttons standards
+    When I validate the forms must have submit buttons standards
     Then it passes
 
   Scenario: Form with no submit button
@@ -38,7 +38,7 @@ Feature: Form Interactions
         <input type="text" name="q" id="q">
       </form>
       """
-    When I validate the form submit buttons standards
+    When I validate the forms must have submit buttons standards
     Then it fails with the message:
       """
       Form has no submit button: /html/body/form
@@ -52,6 +52,5 @@ Feature: Form Interactions
         <button type="submit">Search</button>
       </form>
       """
-    When I validate the form submit buttons standards
+    When I validate the forms must have submit buttons standards
     Then it passes
-

--- a/features/check_standards/form_interactions.feature
+++ b/features/check_standards/form_interactions.feature
@@ -27,7 +27,7 @@ Feature: Form Interactions
         <input type="submit" value="Search">
       </form>
       """
-    When I validate the forms must have submit buttons standards
+    When I validate the "forms must have submit buttons" standard
     Then it passes
 
   Scenario: Form with no submit button
@@ -38,7 +38,7 @@ Feature: Form Interactions
         <input type="text" name="q" id="q">
       </form>
       """
-    When I validate the forms must have submit buttons standards
+    When I validate the "forms must have submit buttons" standard
     Then it fails with the message:
       """
       Form has no submit button: /html/body/form
@@ -52,5 +52,5 @@ Feature: Form Interactions
         <button type="submit">Search</button>
       </form>
       """
-    When I validate the forms must have submit buttons standards
+    When I validate the "forms must have submit buttons" standard
     Then it passes

--- a/features/check_standards/form_labels.feature
+++ b/features/check_standards/form_labels.feature
@@ -29,7 +29,7 @@ Feature: Correctly use form labels
 
       <input type="text" name="q" title="Search the BBC" />
       """
-    When I validate the fields must have labels or titles standards
+    When I validate the "fields must have labels or titles" standard
     Then it passes
 
   Scenario: Some fields without labels or title attributes
@@ -44,7 +44,7 @@ Feature: Correctly use form labels
       <input type="text" name="q" aria-label="Search the BBC" />
       <input type="text" name="q" placeholder="Search the BBC" />
       """
-    When I validate the fields must have labels or titles standards
+    When I validate the "fields must have labels or titles" standard
     Then it fails with the message:
       """
       Field has no label or title attribute: /html/body/textarea
@@ -60,5 +60,5 @@ Feature: Correctly use form labels
       """
       <input type=hidden name=a value=b>
       """
-    When I validate the fields must have labels or titles standards
+    When I validate the "fields must have labels or titles" standard
     Then it passes

--- a/features/check_standards/form_labels.feature
+++ b/features/check_standards/form_labels.feature
@@ -29,7 +29,7 @@ Feature: Correctly use form labels
 
       <input type="text" name="q" title="Search the BBC" />
       """
-    When I validate the form labels standards
+    When I validate the fields must have labels or titles standards
     Then it passes
 
   Scenario: Some fields without labels or title attributes
@@ -44,7 +44,7 @@ Feature: Correctly use form labels
       <input type="text" name="q" aria-label="Search the BBC" />
       <input type="text" name="q" placeholder="Search the BBC" />
       """
-    When I validate the form labels standards
+    When I validate the fields must have labels or titles standards
     Then it fails with the message:
       """
       Field has no label or title attribute: /html/body/textarea
@@ -60,5 +60,5 @@ Feature: Correctly use form labels
       """
       <input type=hidden name=a value=b>
       """
-    When I validate the form labels standards
+    When I validate the fields must have labels or titles standards
     Then it passes

--- a/features/check_standards/headings.feature
+++ b/features/check_standards/headings.feature
@@ -23,7 +23,7 @@ Feature: Headings
       """
       <h2>Heading 2</h2>
       """
-    When I validate the exactly one main heading standards
+    When I validate the "exactly one main heading" standard
     Then it fails with the message:
       """
       Found 0 h1 elements.
@@ -36,7 +36,7 @@ Feature: Headings
       <h2>Heading 2</h2>
       <h1>Heading 1</h1>
       """
-    When I validate the exactly one main heading standards
+    When I validate the "exactly one main heading" standard
     Then it fails with the message:
       """
       Found 2 h1 elements: /html/body/h1[1] /html/body/h1[2]
@@ -52,7 +52,7 @@ Feature: Headings
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it passes
 
   Scenario: Headings in invalid order
@@ -62,7 +62,7 @@ Feature: Headings
       <h3>Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -78,7 +78,7 @@ Feature: Headings
       <h2>Heading 2b</h2>
       <h3>Heading 3b</h3>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it passes
 
   Scenario: Heading is hidden
@@ -88,7 +88,7 @@ Feature: Headings
       <h3 style="display:none">Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it fails with the message:
       """
       Headings are not in order: /html/body/h1 /html/body/h3
@@ -103,7 +103,7 @@ Feature: Headings
       </script>
       <h2>Heading 2</h2>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it passes
 
   Scenario: Subheading before the first main heading
@@ -113,7 +113,7 @@ Feature: Headings
       <h1>Heading 1</h1>
       <h2>Heading 2</h2>
       """
-    When I validate the headings must be in ascending order standards
+    When I validate the "headings must be in ascending order" standard
     Then it passes
 
     Scenario: Content between headings
@@ -132,7 +132,7 @@ Feature: Headings
           non-heading content
         </div>
         """
-      When I validate the content must follow headings standards
+      When I validate the "content must follow headings" standard
       Then it passes
 
   Scenario: No content between headings
@@ -146,7 +146,7 @@ Feature: Headings
         <p>non-heading content</p>
       </div>
       """
-    When I validate the content must follow headings standards
+    When I validate the "content must follow headings" standard
     Then it fails with the message:
       """
       No content follows: /html/body/div/h2[1]

--- a/features/check_standards/headings.feature
+++ b/features/check_standards/headings.feature
@@ -23,10 +23,10 @@ Feature: Headings
       """
       <h2>Heading 2</h2>
       """
-    When I validate the heading standards
+    When I validate the exactly one main heading standards
     Then it fails with the message:
       """
-      A document must have exactly one main heading. Found 0 h1 elements.
+      Found 0 h1 elements.
       """
 
   Scenario: More than one main heading
@@ -36,12 +36,10 @@ Feature: Headings
       <h2>Heading 2</h2>
       <h1>Heading 1</h1>
       """
-    When I validate the heading standards
+    When I validate the exactly one main heading standards
     Then it fails with the message:
       """
-      A document must have exactly one main heading. Found 2 h1 elements:
-      * /html/body/h1[1]
-      * /html/body/h1[2]
+      Found 2 h1 elements: /html/body/h1[1] /html/body/h1[2]
       """
 
   Scenario: Headings in ascending order
@@ -54,7 +52,7 @@ Feature: Headings
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it passes
 
   Scenario: Headings in invalid order
@@ -64,10 +62,10 @@ Feature: Headings
       <h3>Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it fails with the message:
       """
-      Headings are not in order: h1 is followed by h3
+      Headings are not in order: /html/body/h1 /html/body/h3
       """
 
   Scenario: Headings jump back up more than one level
@@ -80,7 +78,7 @@ Feature: Headings
       <h2>Heading 2b</h2>
       <h3>Heading 3b</h3>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it passes
 
   Scenario: Heading is hidden
@@ -90,10 +88,10 @@ Feature: Headings
       <h3 style="display:none">Heading 3</h3>
       <h2>Heading 2</h2>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it fails with the message:
       """
-      Headings are not in order: h1 is followed by h3
+      Headings are not in order: /html/body/h1 /html/body/h3
       """
 
   Scenario: Heading in a script tag
@@ -105,7 +103,7 @@ Feature: Headings
       </script>
       <h2>Heading 2</h2>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it passes
 
   Scenario: Subheading before the first main heading
@@ -115,7 +113,7 @@ Feature: Headings
       <h1>Heading 1</h1>
       <h2>Heading 2</h2>
       """
-    When I validate the heading standards
+    When I validate the headings must be in ascending order standards
     Then it passes
 
     Scenario: Content between headings
@@ -127,13 +125,14 @@ Feature: Headings
           <h2>Another heading</h2>
           <p>non-heading content</p>
           <h3>Main content</h3>
+          non-heading content
           <h2>Secondary content</h2>
           <p>non-heading content</p>
           <h2>Tertiary content</h2>
-          <p>Lorem ipsum…</p>
+          non-heading content
         </div>
         """
-      When I validate the heading standards
+      When I validate the content must follow headings standards
       Then it passes
 
   Scenario: No content between headings
@@ -147,8 +146,8 @@ Feature: Headings
         <p>non-heading content</p>
       </div>
       """
-    When I validate the heading standards
+    When I validate the content must follow headings standards
     Then it fails with the message:
       """
-      Heading elements must be followed by content. No content follows a h2.
+      No content follows: /html/body/div/h2[1]
       """

--- a/features/check_standards/image_alt.feature
+++ b/features/check_standards/image_alt.feature
@@ -23,7 +23,7 @@ Feature: Image alternative content
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" alt="" />
       """
-    When I validate the images must have alt attributes standards
+    When I validate the "images must have alt attributes" standard
     Then it passes
 
   Scenario: Images without alt attributes
@@ -32,7 +32,7 @@ Feature: Image alternative content
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" />
       """
-    When I validate the images must have alt attributes standards
+    When I validate the "images must have alt attributes" standard
     Then it fails with the message:
       """
       Image has no alt attribute: /html/body/img[2]

--- a/features/check_standards/image_alt.feature
+++ b/features/check_standards/image_alt.feature
@@ -23,7 +23,7 @@ Feature: Image alternative content
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" alt="" />
       """
-    When I validate the image alt standards
+    When I validate the images must have alt attributes standards
     Then it passes
 
   Scenario: Images without alt attributes
@@ -32,8 +32,8 @@ Feature: Image alternative content
       <img src="a.jpeg" alt="A picture of something" />
       <img src="b.jpeg" />
       """
-    When I validate the image alt standards
+    When I validate the images must have alt attributes standards
     Then it fails with the message:
       """
-      Image has no alt attribute (src="b.jpeg")
+      Image has no alt attribute: /html/body/img[2]
       """

--- a/features/check_standards/language.feature
+++ b/features/check_standards/language.feature
@@ -23,7 +23,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the language attribute standards
+    When I validate the html must have lang attribute standards
     Then it passes
 
   Scenario: Missing lang attribute on html element
@@ -39,8 +39,8 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the language attribute standards
+    When I validate the html must have lang attribute standards
     Then it fails with the message:
       """
-      The main language must be specified. <html> tag has no lang attribute.
+      html tag has no lang attribute: /html
       """

--- a/features/check_standards/language.feature
+++ b/features/check_standards/language.feature
@@ -23,7 +23,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the html must have lang attribute standards
+    When I validate the "html must have lang attribute" standard
     Then it passes
 
   Scenario: Missing lang attribute on html element
@@ -39,7 +39,7 @@ Feature: Specify content language
         </body>
       </html>
       """
-    When I validate the html must have lang attribute standards
+    When I validate the "html must have lang attribute" standard
     Then it fails with the message:
       """
       html tag has no lang attribute: /html

--- a/features/check_standards/main_landmark.feature
+++ b/features/check_standards/main_landmark.feature
@@ -12,7 +12,7 @@ Feature: Main landmark
       """
       <div role="main">Main element</div>
       """
-    When I validate the exactly one main landmark standards
+    When I validate the "exactly one main landmark" standard
     Then it passes
 
   Scenario: Page has two main elements
@@ -21,7 +21,7 @@ Feature: Main landmark
       <div role="main">Main one</div>
       <div role="main">Main two</div>
       """
-    When I validate the exactly one main landmark standards
+    When I validate the "exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
@@ -32,7 +32,7 @@ Feature: Main landmark
       """
       <div role="not-main">Main one</div>
       """
-    When I validate the exactly one main landmark standards
+    When I validate the "exactly one main landmark" standard
     Then it fails with the message:
       """
       Found 0 elements with role="main".

--- a/features/check_standards/main_landmark.feature
+++ b/features/check_standards/main_landmark.feature
@@ -12,7 +12,7 @@ Feature: Main landmark
       """
       <div role="main">Main element</div>
       """
-    When I validate the landmark standards
+    When I validate the exactly one main landmark standards
     Then it passes
 
   Scenario: Page has two main elements
@@ -21,10 +21,10 @@ Feature: Main landmark
       <div role="main">Main one</div>
       <div role="main">Main two</div>
       """
-    When I validate the landmark standards
+    When I validate the exactly one main landmark standards
     Then it fails with the message:
       """
-      A document must have exactly one main landmark. Found 2 elements with role="main".
+      Found 2 elements with role="main": /html/body/div[1] /html/body/div[2]
       """
 
   Scenario: Page has zero main elements
@@ -32,8 +32,8 @@ Feature: Main landmark
       """
       <div role="not-main">Main one</div>
       """
-    When I validate the landmark standards
+    When I validate the exactly one main landmark standards
     Then it fails with the message:
       """
-      A document must have exactly one main landmark. Found 0 elements with role="main".
+      Found 0 elements with role="main".
       """

--- a/features/check_standards/minimum_text_size.feature
+++ b/features/check_standards/minimum_text_size.feature
@@ -26,7 +26,7 @@ Feature: Minimum text size
       </style>
       <span>Some text</span> with <span>more <b>text</b> also</span>.
       """
-    When I validate the minimum text size standards
+    When I validate the "minimum text size" standard
     Then it fails with the message:
       """
       Text size too small (10px): /html/body

--- a/features/check_standards/minimum_text_size.feature
+++ b/features/check_standards/minimum_text_size.feature
@@ -1,0 +1,36 @@
+Feature: Minimum text size
+
+  At default browser level all text **must** have a minimum calculated size of
+  11px and all core content **must** have a minimum calculated size of 13px.
+
+  Rationale
+  =========
+
+  Having a minimum text size will reduce the number of users who need to make
+  use of browser based text resize or page zoom. This is a particular issue with
+  an ageing audience, many of whom will not consider themselves as having low
+  vision and there will not have access to assistive technology or be familiar
+  with browser tools to resize content.
+
+  Scenario: Small text
+    Given a page with the HTML:
+      """
+      <style>
+        body {
+          font-size: 62.5%; /* Set default size of 1em to 10px */
+        }
+
+        b {
+          font-size: 9px;
+        }
+      </style>
+      <span>Some text</span> with <span>more <b>text</b> also</span>.
+      """
+    When I validate the minimum text size standards
+    Then it fails with the message:
+      """
+      Text size too small (10px): /html/body
+      Text size too small (10px): /html/body/span[1]
+      Text size too small (10px): /html/body/span[2]
+      Text size too small (9px): /html/body/span[2]/b
+      """

--- a/features/check_standards/tab_index.feature
+++ b/features/check_standards/tab_index.feature
@@ -24,7 +24,7 @@ Feature: Correctly use `tabindex` attributes
       <button type="submit">Search</button>
       <div tabindex="-1"></div>
       """
-    When I validate the elements with zero tab index must be fields standards
+    When I validate the "elements with zero tab index must be fields" standard
     Then it passes
 
   Scenario: Focusable elements with zero tab index
@@ -36,7 +36,7 @@ Feature: Correctly use `tabindex` attributes
       <select tabindex="0"></select>
       <textarea tabindex="0"></textarea>
       """
-    When I validate the elements with zero tab index must be fields standards
+    When I validate the "elements with zero tab index must be fields" standard
     Then it passes
 
   Scenario: Unfocusable element with zero tab index
@@ -47,7 +47,7 @@ Feature: Correctly use `tabindex` attributes
       <div tabindex="3"></div>
       <div tabindex="0"></div>
       """
-    When I validate the elements with zero tab index must be fields standards
+    When I validate the "elements with zero tab index must be fields" standard
     Then it fails with the message:
       """
       Non-field element with tabindex=0: /html/body/div[2]

--- a/features/check_standards/tab_index.feature
+++ b/features/check_standards/tab_index.feature
@@ -24,7 +24,7 @@ Feature: Correctly use `tabindex` attributes
       <button type="submit">Search</button>
       <div tabindex="-1"></div>
       """
-    When I validate the tab index standards
+    When I validate the elements with zero tab index must be fields standards
     Then it passes
 
   Scenario: Focusable elements with zero tab index
@@ -36,7 +36,7 @@ Feature: Correctly use `tabindex` attributes
       <select tabindex="0"></select>
       <textarea tabindex="0"></textarea>
       """
-    When I validate the tab index standards
+    When I validate the elements with zero tab index must be fields standards
     Then it passes
 
   Scenario: Unfocusable element with zero tab index
@@ -47,8 +47,8 @@ Feature: Correctly use `tabindex` attributes
       <div tabindex="3"></div>
       <div tabindex="0"></div>
       """
-    When I validate the tab index standards
+    When I validate the elements with zero tab index must be fields standards
     Then it fails with the message:
       """
-      tabindex="0" must not be used on <div> elements (not focusable by default)
+      Non-field element with tabindex=0: /html/body/div[2]
       """

--- a/features/check_standards/title_attribute.feature
+++ b/features/check_standards/title_attribute.feature
@@ -23,7 +23,7 @@ Feature: Correctly use `title` attributes
         <img src="close.png" />
       </button>
       """
-    When I validate the title attribute standards
+    When I validate the title attributes only on inputs standards
     Then it passes
 
   Scenario: Anchor tag with title attribute
@@ -33,8 +33,8 @@ Feature: Correctly use `title` attributes
         <img src="close.png" />
       </a>
       """
-    When I validate the title attribute standards
+    When I validate the title attributes only on inputs standards
     Then it fails with the message:
       """
-      Element (not a form input) has a title attribute: /html/body/a
+      Non-input element has title attribute: /html/body/a
       """

--- a/features/check_standards/title_attribute.feature
+++ b/features/check_standards/title_attribute.feature
@@ -23,7 +23,7 @@ Feature: Correctly use `title` attributes
         <img src="close.png" />
       </button>
       """
-    When I validate the title attributes only on inputs standards
+    When I validate the "title attributes only on inputs" standard
     Then it passes
 
   Scenario: Anchor tag with title attribute
@@ -33,7 +33,7 @@ Feature: Correctly use `title` attributes
         <img src="close.png" />
       </a>
       """
-    When I validate the title attributes only on inputs standards
+    When I validate the "title attributes only on inputs" standard
     Then it fails with the message:
       """
       Non-input element has title attribute: /html/body/a

--- a/features/cli/display_failing_result.feature
+++ b/features/cli/display_failing_result.feature
@@ -6,5 +6,5 @@ Feature: Display failing result
     Then it should fail with:
       """
       ✗ http://localhost:54321/missing_header.html
-        - A document must have exactly one main heading. Found 0 h1 elements.
+        - Found 0 h1 elements.
       """

--- a/features/cli/display_result_summary.feature
+++ b/features/cli/display_result_summary.feature
@@ -7,7 +7,7 @@ Feature: Display result summary
       page "http://localhost:54321/perfect.html"
       page "http://localhost:54321/missing_header.html"
       page "http://localhost:54321/missing_header.html?again!" do
-        skip_standard /ExactlyOneMainHeading/
+        skip_standard "exactly one main heading"
       end
       """
     When I run `a11y`

--- a/features/cli/skipping_standards.feature
+++ b/features/cli/skipping_standards.feature
@@ -5,7 +5,7 @@ Feature: Skipping Standards
     And a file named "a11y.rb" with:
       """
       page "http://localhost:54321/missing_header.html" do
-        skip_standard /head/i
+        skip_standard "exactly one main heading"
       end
       """
     When I run `a11y`

--- a/features/mute_errors.feature
+++ b/features/mute_errors.feature
@@ -19,7 +19,7 @@ Feature: Mute errors
     When I validate the exactly one main heading standard
     Then it fails with the message:
       """
-      A document must have exactly one main heading. Found 0 h1 elements.
+      Found 0 h1 elements.
       """
     When I add a configuration with:
       """

--- a/features/mute_errors.feature
+++ b/features/mute_errors.feature
@@ -16,7 +16,7 @@ Feature: Mute errors
       """
       <p>yo</p>
       """
-    When I validate the exactly one main heading standard
+    When I validate the "exactly one main heading" standard
     Then it fails with the message:
       """
       Found 0 h1 elements.
@@ -27,6 +27,6 @@ Feature: Mute errors
           "exactly-one-main-heading"
         ]
       """
-    And I validate the exactly one main heading standard
+    And I validate the "exactly one main heading" standard
     Then it shows 0 errors, 1 muted
     And it passes

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -27,9 +27,9 @@ After do
   WebServer.delete_page "scenario.html"
 end
 
-When(/^I validate the (.+) standards?$/) do |pattern|
+When(/^I validate the \"([^\"]+)\" standard$/) do |standard_name|
   browser.execute_script(BBC::A11y::Javascript.bundle)
-  validation = browser.evaluate_script("a11y.validate(#{pattern.to_json})")
+  validation = browser.evaluate_script("a11y.validate(#{standard_name.to_json})")
   if validation['results'].size != 1
     raise "#{validation['results'].size} standards match '#{pattern}'"
   end

--- a/features/support/browserify.rb
+++ b/features/support/browserify.rb
@@ -1,0 +1,3 @@
+Before do
+  $browserify_output ||= `npm run browserify`
+end

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,0 +1,49 @@
+require 'capybara'
+require 'capybara/dsl'
+require 'phantomjs/poltergeist'
+
+Capybara.default_driver = :poltergeist
+
+Before do
+  Capybara.use_default_driver
+end
+
+After do
+  Capybara.reset_sessions!
+end
+
+module BBC
+  module A11y
+
+    module Browser
+      def browser
+        Capybara.current_session
+      end
+
+      def disable_javascript_and_css
+        unless Capybara.drivers.keys.include?(:without_js)
+          skip_this_scenario <<-ERROR
+You need to define a non-javascript driver for Capybara in order to run this scenario. Here's an example you could use:
+
+    require 'capybara/selenium'
+    Capybara.register_driver(:without_javascript_or_css) do |app|
+      profile = Selenium::WebDriver::Firefox::Profile.new
+      profile['permissions.default.stylesheet'] = 2
+      profile['javascript.enabled'] = false
+      Capybara::Selenium::Driver.new(app, profile: profile)
+    end
+
+You can put this code into your a11y.rb file
+
+You'll also need to add the `selenium-webdriver` gem to your Gemfile.
+          ERROR
+        else
+          Capybara.current_driver = :without_js
+        end
+      end
+    end
+
+  end
+end
+
+World(BBC::A11y::Browser)

--- a/features/support/web_server.rb
+++ b/features/support/web_server.rb
@@ -13,11 +13,11 @@ class WebServer
 
     def options(port)
       default = {
-        :Port => port.to_i, 
-        :DocumentRoot => DOCUMENT_ROOT, 
+        :Port => port.to_i,
+        :DocumentRoot => DOCUMENT_ROOT,
       }
       disable_logging = {
-        :AccessLog => [], 
+        :AccessLog => [],
         :Logger => WEBrick::Log::new("/dev/null", 7)
       }
       unless ENV['DEBUG']
@@ -25,6 +25,17 @@ class WebServer
       else
         default
       end
+    end
+
+    def write_page(path, html)
+      full_path = File.join(DOCUMENT_ROOT, path)
+      File.open(full_path, 'w') { |file| file.write(html) }
+    end
+
+    def delete_page(path)
+      full_path = File.join(DOCUMENT_ROOT, path)
+      File.delete(full_path)
+    rescue Errno::ENOENT
     end
   end
 end

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,57 @@
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'browserify'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'spec/bbc/a11y/js/*Spec.js'
+    ],
+
+    // list of files to exclude
+    exclude: [
+      '**/.*.sw?'
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'spec/bbc/a11y/js/*Spec.js': ['browserify']
+    },
+
+    browserify: {
+      debug: true
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['mocha'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_WARN,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/lib/bbc/a11y/cli.rb
+++ b/lib/bbc/a11y/cli.rb
@@ -23,12 +23,12 @@ module BBC
         exit_with_message error.message
       end
 
-      def page_tested(page_settings, errors)
-        if errors.empty?
+      def page_tested(page_settings, lint_result)
+        if lint_result.passed?
           stdout.puts green("✓ #{page_settings.url}")
         else
           stdout.puts red("✗ #{page_settings.url}")
-          stdout.puts errors.map { |error| "  - #{error}" }.join("\n")
+          stdout.puts lint_result.errors.map { |error| "  - #{error}" }.join("\n")
         end
         stdout.puts ""
       end

--- a/lib/bbc/a11y/javascript.rb
+++ b/lib/bbc/a11y/javascript.rb
@@ -1,0 +1,13 @@
+module BBC
+  module A11y
+    class Javascript
+      def self.bundle
+        @@bundle ||= File.read(bundle_path)
+      end
+
+      def self.bundle_path
+        File.expand_path("../js/bundle.js", __FILE__)
+      end
+    end
+  end
+end

--- a/lib/bbc/a11y/js/a11y.js
+++ b/lib/bbc/a11y/js/a11y.js
@@ -1,0 +1,10 @@
+var jquery = require('jquery');
+var standards = require('./standards');
+
+window.a11y = {
+  validate: function(pattern) {
+    return standards.matching(pattern).validate(jquery);
+  }
+};
+
+module.exports = window.a11y;

--- a/lib/bbc/a11y/js/standards.js
+++ b/lib/bbc/a11y/js/standards.js
@@ -1,0 +1,80 @@
+var xpath = require('./xpath');
+
+function Standards(standards, skipped) {
+  this.standards = standards;
+  this.skipped = skipped;
+}
+
+Standards.all = [
+  require('./standards/anchorsMustHaveHrefs'),
+  require('./standards/contentMustFollowHeadings'),
+  require('./standards/elementsWithZeroTabIndexMustBeFields'),
+  require('./standards/exactlyOneMainHeading'),
+  require('./standards/exactlyOneMainLandmark'),
+  require('./standards/fieldsMustHaveLabelsOrTitles'),
+  require('./standards/formsMustHaveSubmitButtons'),
+  require('./standards/headingsMustBeInAscendingOrder'),
+  require('./standards/htmlMustHaveLangAttribute'),
+  require('./standards/imagesMustHaveAltAttributes'),
+  require('./standards/minimumTextSize'),
+  require('./standards/titleAttributesOnlyOnInputs')
+];
+
+Standards.prototype.validate = function(jquery) {
+  var results = [];
+  var standardResult;
+  function fail() {
+    standardResult.errors.push(xpath.replaceElementsWithXPaths(arguments));
+  }
+  for (var i = 0; i < this.standards.length; ++i) {
+    standard = this.standards[i];
+    standardResult = { standard: this.standards[i].name, errors: [] };
+    standard.validate(jquery, fail);
+    results.push(standardResult);
+  }
+  return { results: results, skipped: this.skipped };
+}
+
+Standards.matching = function(criteria) {
+  if (typeof(criteria) == 'undefined') {
+    return Standards.matching({});
+  }
+  if (typeof(criteria) == 'string') {
+    return Standards.matching({ only: criteria });
+  }
+  var matching = standardsMatching(criteria);
+  return new Standards(matching.matches, matching.skipped);
+}
+
+function standardsMatching(criteria) {
+  var skips = criteria.skip || [];
+  for (var i = 0; i < skips.length; ++i) {
+    skips[i] = normalise(skips[i]);
+  }
+  var isOnly = typeof(criteria.only) == 'string';
+  var only = isOnly ? normalise(criteria.only) : null;
+  var matches = [];
+  var skipped = [];
+  for (var i = 0; i < Standards.all.length; ++i) {
+    var standard = Standards.all[i];
+    var name = normalise(standard.name);
+    if (isOnly) {
+      if (only == name) {
+        matches.push(standard);
+      } else {
+        skipped.push(standard.name);
+      }
+    } else if (skips.indexOf(name) == -1) {
+      matches.push(standard);
+    } else {
+      skipped.push(standard.name);
+    }
+  }
+  return { matches: matches, skipped: skipped };
+}
+
+function normalise(name) {
+  return name.replace(/\s+/g, '').toLowerCase();
+}
+
+module.exports = Standards;

--- a/lib/bbc/a11y/js/standards/anchorsMustHaveHrefs.js
+++ b/lib/bbc/a11y/js/standards/anchorsMustHaveHrefs.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'Anchors must have hrefs',
+
+  validate: function($, fail) {
+    $("a:not([href])").each(function(index, anchor) {
+      fail('Anchor has no href attribute:', anchor);
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/contentMustFollowHeadings.js
+++ b/lib/bbc/a11y/js/standards/contentMustFollowHeadings.js
@@ -1,0 +1,15 @@
+var headingSelector = 'h1, h2, h3, h4, h5, h6, h7, h8';
+
+module.exports = {
+  name: 'Content must follow headings',
+
+  validate: function($, fail) {
+    $(headingSelector).each(function(index, heading) {
+      if ($(heading.nextSibling).is(headingSelector) ||
+         ($(heading.nextSibling).text().trim() == '' &&
+          $(heading).next().is(headingSelector))) {
+        fail("No content follows:", heading);
+      }
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/elementsWithZeroTabIndexMustBeFields.js
+++ b/lib/bbc/a11y/js/standards/elementsWithZeroTabIndexMustBeFields.js
@@ -1,0 +1,10 @@
+module.exports = {
+  name: 'Elements with zero tab index must be fields',
+
+  validate: function($, fail) {
+    var baddies = $("*[tabindex='0']:not(input, button, select, textarea, a)");
+    baddies.each(function(index, el) {
+      fail('Non-field element with tabindex=0:', el);
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/exactlyOneMainHeading.js
+++ b/lib/bbc/a11y/js/standards/exactlyOneMainHeading.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'Exactly one main heading',
+
+  validate: function($, fail) {
+    var mainHeadings = $('h1');
+    var count = mainHeadings.length;
+    if (count == 0) {
+      fail('Found 0 h1 elements.');
+    } else if (count > 1) {
+      fail('Found ' + count + ' h1 elements:', mainHeadings);
+    }
+  }
+}

--- a/lib/bbc/a11y/js/standards/exactlyOneMainLandmark.js
+++ b/lib/bbc/a11y/js/standards/exactlyOneMainLandmark.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'Exactly one main landmark',
+
+  validate: function($, fail) {
+    var mainLandmarks = $("[role='main']");
+    var count = mainLandmarks.length;
+    if (count == 0) {
+      fail('Found 0 elements with role="main".');
+    } else if (count > 1) {
+      fail('Found ' + count + ' elements with role="main":', mainLandmarks);
+    }
+  }
+}

--- a/lib/bbc/a11y/js/standards/fieldsMustHaveLabelsOrTitles.js
+++ b/lib/bbc/a11y/js/standards/fieldsMustHaveLabelsOrTitles.js
@@ -1,0 +1,26 @@
+function hasIdOrLabel(field) {
+  return hasId(field) || hasLabel(field);
+}
+
+function hasId(field) {
+  return field.is('[id]')
+}
+
+function hasLabel(field) {
+  var selector = "label[for='" + field.attr('id') + "']";
+  return field.parents('body').find(selector).length > 0;
+}
+
+module.exports = {
+  name: 'Fields must have labels or titles',
+
+  validate: function($, fail) {
+    $("input:not([type='hidden']):not([title]), " +
+      "textarea:not([title]), " +
+      "select:not([title])").each(function(index, field) {
+      if (!hasIdOrLabel($(field))) {
+        fail('Field has no label or title attribute:', field)
+      }
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/formsMustHaveSubmitButtons.js
+++ b/lib/bbc/a11y/js/standards/formsMustHaveSubmitButtons.js
@@ -1,0 +1,12 @@
+module.exports = {
+  name: 'Forms must have submit buttons',
+
+  validate: function($, fail) {
+    $("form").each(function(index, form) {
+      var submits = $(form).find("input[type=submit], button[type=submit]");
+      if (submits.length == 0) {
+        fail('Form has no submit button:', form);
+      }
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/headingsMustBeInAscendingOrder.js
+++ b/lib/bbc/a11y/js/standards/headingsMustBeInAscendingOrder.js
@@ -1,0 +1,31 @@
+module.exports = {
+  name: 'Headings must be in ascending order',
+
+  validate: function($, fail) {
+    var headings = $('h1, h2, h3, h4, h5, h6');
+    var headingLevels = headings.map(function(index, heading) {
+      return { heading: heading, level: parseInt(heading.tagName[1]) };
+    });
+    eachCons(headingLevels, 2).forEach(function(pair) {
+      if (pair[1].level > (pair[0].level + 1)) {
+        fail("Headings are not in order:", pair[0].heading, pair[1].heading);
+      }
+    })
+  }
+}
+
+function eachCons(a, n) {
+  var r = []
+  for (var i = 0; i < a.length - n + 1; i++) {
+    r.push(range(a, i, n))
+  }
+  return r
+}
+
+function range(a, i, n) {
+  var r = []
+  for (var j = 0; j < n; j++) {
+    r.push(a[i + j])
+  }
+  return r
+}

--- a/lib/bbc/a11y/js/standards/htmlMustHaveLangAttribute.js
+++ b/lib/bbc/a11y/js/standards/htmlMustHaveLangAttribute.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'Html must have lang attribute',
+
+  validate: function($, fail) {
+    $("html:not([lang])").each(function(index, html) {
+      fail('html tag has no lang attribute:', html);
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/imagesMustHaveAltAttributes.js
+++ b/lib/bbc/a11y/js/standards/imagesMustHaveAltAttributes.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'Images must have alt attributes',
+
+  validate: function($, fail) {
+    $("img:not([alt])").each(function(index, img) {
+      fail('Image has no alt attribute:', img);
+    });
+  }
+}

--- a/lib/bbc/a11y/js/standards/minimumTextSize.js
+++ b/lib/bbc/a11y/js/standards/minimumTextSize.js
@@ -1,0 +1,25 @@
+module.exports = {
+  name: 'Minimum text size',
+
+  validate: function($, fail) {
+    var textNodes = $('*:not(head, script, style)').contents().filter(function() {
+      return this.nodeType === 3;
+    });
+
+    var parents = [];
+    textNodes.each(function(index, node) {
+      var parent = $(node).parent()[0];
+      if (parents.indexOf(parent) == -1) {
+        parents.push(parent);
+      }
+    });
+
+    for (var i = 0; i < parents.length; ++i) {
+      var element = $(parents[i]);
+      var size = parseInt(element.css('fontSize').replace('px', ''), 10);
+      if (size < 11) {
+        fail('Text size too small (' + size + 'px):', element);
+      }
+    }
+  }
+}

--- a/lib/bbc/a11y/js/standards/titleAttributesOnlyOnInputs.js
+++ b/lib/bbc/a11y/js/standards/titleAttributesOnlyOnInputs.js
@@ -1,0 +1,9 @@
+module.exports = {
+  name: 'Title attributes only on inputs',
+
+  validate: function($, fail) {
+    $("[title]:not(input, button, textarea, select)").each(function(index, element) {
+      fail('Non-input element has title attribute:', element);
+    });
+  }
+}

--- a/lib/bbc/a11y/js/xpath.js
+++ b/lib/bbc/a11y/js/xpath.js
@@ -1,0 +1,45 @@
+function replaceElementsWithXPaths(things) {
+  var thangs = [];
+  for (var i = 0; i < things.length; ++i) {
+    thangs = thangs.concat(replaceElementWithXPaths(things[i]));
+  }
+  return thangs;
+}
+
+function xpathForElement(node) {
+  if (!node.tagName) return '';
+  var xpath = '/' + node.tagName.toLowerCase();
+  if (node.parentNode) {
+    xpath = xpathForElement(node.parentNode) + xpath;
+    var sameTags = childrenWithTagName(node.parentNode, node.tagName);
+    if (sameTags.length > 1) {
+      xpath += '[' + (sameTags.indexOf(node) + 1) + ']';
+    }
+  }
+  return xpath;
+}
+
+function childrenWithTagName(element, tagName) {
+  if (!element.children) return [];
+  var children = [];
+  for (var i = 0; i < element.children.length; ++i) {
+    if (element.children[i].tagName == tagName) {
+      children.push(element.children[i]);
+    }
+  }
+  return children;
+}
+
+function replaceElementWithXPaths(el) {
+  if (el instanceof Array) {
+    return [].concat.apply([], el.map(replaceElementWithXPaths));
+  } else if (typeof(el.tagName) == 'string') {
+    return xpathForElement(el);
+  } else if (typeof(el.get) == 'function') {
+    return replaceElementWithXPaths(el.get());
+  } else {
+    return el;
+  }
+}
+
+module.exports.replaceElementsWithXPaths = replaceElementsWithXPaths;

--- a/lib/bbc/a11y/runner.rb
+++ b/lib/bbc/a11y/runner.rb
@@ -2,6 +2,10 @@ require 'bbc/a11y/standards'
 require 'bbc/a11y/javascript'
 require 'phantomjs/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, js_errors: false)
+end
+
 Capybara.default_driver = :poltergeist
 
 module BBC

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "bbc-a11y",
+  "version": "1.0.0",
+  "description": "BBC Accessibility standards checker",
+  "main": "index.js",
+  "directories": {},
+  "scripts": {
+    "browserify": "browserify ./lib/bbc/a11y/js/a11y.js -o ./lib/bbc/a11y/js/bundle.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cucumber-ltd/bbc-a11y.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/cucumber-ltd/bbc-a11y/issues"
+  },
+  "homepage": "https://github.com/cucumber-ltd/bbc-a11y#readme",
+  "devDependencies": {
+    "browser-monkey": "^1.26.3",
+    "browserify": "^12.0.1",
+    "chai": "^3.4.1",
+    "jquery": "^2.1.4",
+    "karma": "^0.13.16",
+    "karma-browserify": "^4.4.2",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-mocha": "^0.2.1",
+    "karma-mocha-reporter": "^1.1.3",
+    "mocha": "^2.3.4",
+    "watchify": "^3.6.1"
+  }
+}

--- a/spec/bbc/a11y/js/a11ySpec.js
+++ b/spec/bbc/a11y/js/a11ySpec.js
@@ -1,0 +1,42 @@
+var a11y = require('../../../../lib/bbc/a11y/js/a11y.js');
+var expect = require('chai').expect;
+var $ = require('jquery');
+
+describe('a11y', function() {
+  beforeEach(function() {
+    $('body').html('');
+  })
+
+  it('validates the DOM', function() {
+    var validation = a11y.validate();
+    var errors = validation.results.filter(function(standardResult) {
+      return standardResult.errors.length > 0;
+    });
+    var expectedErrors = [
+      {
+        "standard":"Exactly one main heading",
+        "errors":[
+          ["Found 0 h1 elements."]
+        ]
+      },
+      {
+        "standard":"Exactly one main landmark",
+        "errors":[
+          ['Found 0 elements with role="main".']
+        ]
+      },
+      {
+        "standard":"Html must have lang attribute",
+        "errors":[
+          ["html tag has no lang attribute:","/html"]
+        ]
+      }
+    ];
+    expect(JSON.stringify(errors)).to.equal(JSON.stringify(expectedErrors));
+  });
+
+  it('skips standards', function() {
+    var validation = a11y.validate({ skip: ['Exactly one main landmark'] });
+    expect(validation.skipped).to.eql(['Exactly one main landmark']);
+  });
+});

--- a/spec/bbc/a11y/js/standardsSpec.js
+++ b/spec/bbc/a11y/js/standardsSpec.js
@@ -1,0 +1,32 @@
+var standards = require('../../../../lib/bbc/a11y/js/standards.js');
+var expect = require('chai').expect;
+
+describe('standards', function() {
+  describe('.matching(undefined)', function() {
+    it('finds all standards', function() {
+      var matches = standards.matching();
+      expect(matches.standards.length).to.equal(standards.all.length);
+    });
+  });
+
+  describe('.matching(string)', function() {
+    it('finds standards matching the string', function() {
+      var matches = standards.matching('anchors must have hrefs');
+      expect(matches.standards.length).to.equal(1);
+    });
+  });
+
+  describe('.matching({ skip: ["anchors must have hrefs"] })', function() {
+    it('finds all standards except one', function() {
+      var matches = standards.matching({ skip: ["anchors must have hrefs"] });
+      expect(matches.standards.length).to.equal(standards.all.length - 1);
+    });
+  });
+
+  describe('.matching({ only: "anchors must have hrefs" })', function() {
+    it('finds one standard', function() {
+      var matches = standards.matching({ only: "anchors must have hrefs" });
+      expect(matches.standards.length).to.equal(1);
+    });
+  });
+});

--- a/spec/bbc/a11y/js/xpathSpec.js
+++ b/spec/bbc/a11y/js/xpathSpec.js
@@ -1,0 +1,31 @@
+var xpath = require('../../../../lib/bbc/a11y/js/xpath.js');
+var expect = require('chai').expect;
+var $ = require('jquery');
+
+describe('xpath', function() {
+  describe('.replaceElementsWithXPaths()', function() {
+    it('replaces element values with xpaths', function() {
+      var values = [document.head, document.body];
+      var replaced = xpath.replaceElementsWithXPaths(values);
+      expect(replaced).to.eql(['/html/head', '/html/body']);
+    });
+
+    it('replaces jquery values with xpaths', function() {
+      var values = [$(document.head), $(document.body)];
+      var replaced = xpath.replaceElementsWithXPaths(values);
+      expect(replaced).to.eql(['/html/head', '/html/body']);
+    });
+
+    it('replaces non-element values with themselves', function() {
+      var values = [1, 'two'];
+      var replaced = xpath.replaceElementsWithXPaths(values);
+      expect(replaced).to.eql(values);
+    });
+
+    it('replaces elements in nested arrays', function() {
+      var values = [1, [document.body], [[$(document.head)]]];
+      var replaced = xpath.replaceElementsWithXPaths(values);
+      expect(replaced).to.eql([1, '/html/body', '/html/head']);
+    });
+  });
+});

--- a/standards/support/capybara.rb
+++ b/standards/support/capybara.rb
@@ -2,6 +2,10 @@ require 'capybara'
 require 'capybara/dsl'
 require 'phantomjs/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, js_errors: false)
+end
+
 Capybara.default_driver = :poltergeist
 
 Before do


### PR DESCRIPTION
As per https://github.com/cucumber-ltd/bbc-a11y/issues/57

This change reimplements the standards in JavaScript, using a real browser and DOM. The ruby linter now sends a bundle of JavaScript to a capybara browser, which checks the page and reports the results of all standards in a single operation against each web page. That means we check standards against the page *after css and javascript* which means we can test standards that depend on CSS, like in the [minimum font size standard](https://github.com/cucumber-ltd/bbc-a11y/blob/d13737a85ffb3e0422e887845aa05c39bc239057/features/check_standards/minimum_text_size.feature) which is implemented in this branch.

This makes a11y quite a bit slower and more cumbersome (poltergeist/selenium dependencies). I think that's mainly a CLI startup cost, forking processes, but since we do that in all the CLI features, the features take about 30s for me now.

In my mind, the main benefit of implementing the standards in JavaScript, designed to be used against a real DOM, is that they can be used interactively in the browser, e.g. in a chrome extension. We could still use a pure JavaScript dom implementation (e.g. jsdom) if we want a11y to be fast and still use the same standards logic as the interactive browser version.

This branch fixes https://github.com/cucumber-ltd/bbc-a11y/issues/65 with a richer model for error messages and probably also https://github.com/cucumber-ltd/bbc-a11y/issues/59 (because jquery not cheerio)

What do you think @mattwynne?