### PR TITLE
Split readme into two docs, one for users, one for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,77 @@
-# BBC A11y Contributing guidelines
+# BBC A11y Contributing Guidelines
 
-The standards are all stored in the `standards` directory.
+## How can I contribute?
 
-You can run a manual test of your development copy of a11y at any time just by running:
+We welcome contributions of all shapes and sizes, but we prefer them in the form
+of Github issues or pull requests. Please have a quick look at our existing
+issues before posting, as you may find we are already thinking about or working
+on a fix.
 
-    bundle exec ./bin/a11y <url>
+## Improving standards checks
 
-You can also use cucumber to run one specific test:
+If you believe there is a bug or misinterpretation of the BBC Accessibility
+Guidelines, please submit an issue with as much relevant detail as possible.
+Ideally this should include an HTML snippet that demonstrates the problem. Even
+more ideally, you can create or amend a scenario in one of our [cucumber features](features/check_standards).
 
-    A11Y_URL=<url> bundle exec cucumber features/04_language.feature
+## Contributing code
 
-The step definitions behind these features are shallow wrappers that delegate to objects in `lib/bbc/a11y/`. Those objects are unit-tested to ensure they'll behave as expected when tests pass or fail.
+Contributions of code are very welcome. You'll need to do a little bit more
+setup before you can start hacking on the code:
 
-To add new behaviour, test-drive changes to the objects in `lib`.
+### Prerequisites
+
+You'll need to install a few things on your system before you can work on the
+code:
+
+  * Ruby (1.9.3 is required, 2.0+ is recommended)
+  * node.js (5.0+ is recommended)
+  * phantomjs
+
+Once those are installed, you can install the Ruby dependencies:
+
+  ```
+  bundle install
+  ```
+
+...and the node.js dependencies:
+
+  ```
+  npm install
+  ```
+
+...then finally run all the tests to verify:
+
+  ```
+  bundle exec rake
+  ```
+
+You should see red if anything fails. If all tests pass, you are ready to start
+hacking! If not, please get in touch and we'll help you figure it out.
+
+### Amending features
+
+It usually makes sense to start by briefly reviewing the [cucumber
+features](features) as there may be similar scenarios already implemented. Then
+change the features, or add scenarios to cover new edge cases, or create new
+feature files.
+
+When you are done changing feature files, we recommend that you submit a pull
+request, to get feedback from the a11y team before implementing your change.
+
+### Implementing code changes
+
+When it's time to implement your changes, you might need to write Ruby, or
+JavaScript, or both. The standards checks are implemented in JavaScript,
+whereas the command-line runner is implemented in Ruby.
+
+There are high-level cucumber features, and low-level specs for both Ruby and
+JavaScript. The cucumber features are generally broad in scope have more moving
+parts, so depending on the change, it can be difficult to understand why things
+fail, and to iterate on changes. In this case you should consider writing or
+amending the low-level [JavaScript specs for the standards](spec/bbc/a11y/js)
+or [Ruby specs for the runner](spec/bbc/a11y).
+
+When all tests pass, please submit a pull request and the team will review it.
+
+Happy hacking!

--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -1,0 +1,65 @@
+## BBC A11y User Guide
+
+## Installing bbc-a11y to validate your project
+
+bbc-a11y is packaged as a Ruby gem. You'll most likely want to create a
+stand-alone repo to run your accessibility tests, but you can also add it as
+part of an existing repo.
+
+### Prerequisites
+
+[Install Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
+then:
+
+    gem install bundler
+
+### Adding a11y to your project's Gemfile
+
+Create or amend your your project's `Gemfile` to include this line:
+
+    gem 'bbc-a11y`
+
+Now install the gem:
+
+    bundle install
+
+## Configuring a11y for your project
+
+You'll need to configure a11y with a set of URLs to run the checks against.
+Create a file called `a11y.rb` in the root of your project that looks something
+like this:
+
+```
+page "http://bbc.co.uk"
+page "http://bbc.co.uk/news"
+```
+
+### Skipping standards checks
+
+Nobody's perfect. Use `skip_standard` in the configuration to opt-out of certain
+checks.
+
+```
+page "http://bbc.co.uk" do
+  skip_standard 'anchors must have hrefs'
+end
+
+page "http://bbc.co.uk/news"
+```
+
+A11y will skip any standards from whose name matches that string.
+
+## Running it
+
+Once you're configured, you can run the tests using the `a11y` command, from the
+directory where your `a11y.rb` configuration file is stored:
+
+    bundle exec a11y
+
+This will pick up your `a11y.rb` configuration file and run the a11y checks on
+each page specified in your configuration. Output is printed to the console.
+
+## Using a11y in build scripts
+
+The `a11y` executable will exit with a non-zero status code if there are any
+standards failures, for convenient integration with CI tools like Jenkins.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,20 @@
 [![Circle CI](https://circleci.com/gh/cucumber-ltd/bbc-a11y.svg?style=svg&circle-token=00d656fd091643ad692c78ca60e30ad95df9563a)](https://circleci.com/gh/cucumber-ltd/bbc-a11y)
 
-#BBC Accessibility Standards
+# BBC Accessibility Standards Checker
 
-This tool runs a set of tests against a set of URLs to verify whether each one meets the [BBC accessibility standards](http://www.bbc.co.uk/guidelines/futuremedia/accessibility/).
+This tool runs a set of tests against a set of URLs to verify whether each one
+meets the [BBC accessibility
+standards](http://www.bbc.co.uk/guidelines/futuremedia/accessibility/).
 
-## How to install
+This project is a work in progress, but it is stable and you can use it in your
+project today.
 
-bbc-a11y is packaged as a Ruby gem. You'll most likely want to create a stand-alone repo to run your accessibilty tests,
-but you can also add it as part of an existing repo.
+## Using BBC A11y
 
-### Prerequisites
+The [getting started guide](GETTINGSTARTED.md) shows how to use a11y in your
+project.
 
-[Install Ruby](https://www.ruby-lang.org/en/documentation/installation/) and then:
+## Contributing to BBC A11y
 
-    gem install bundler
-
-### Adding a11y to your project's Gemfile
-
-Create or amend your your project's `Gemfile` to include this line:
-
-    gem 'bbc-a11y`
-
-Now install the gem:
-
-    bundle install
-
-## Configuration
-
-You'll need to configure a11y with a set of URLs to run the checks against. Create a file `a11y.rb` in the root of your project that looks something like this:
-
-```
-page "http://bbc.co.uk"
-page "http://bbc.co.uk/news"
-```
-
-### Skipping scenarios
-
-Nobody's perfect. Use `skip_standard` in the configuration to opt-out of certain checks.
-
-```
-page "http://bbc.co.uk" do
-  skip_standard 'anchors must have hrefs'
-end
-
-page "http://bbc.co.uk/news"
-```
-
-A11y will skip any scenarios from the specifications whose name contains that string.
-
-## Running it
-
-Once you're configured, you can run the tests using the `a11y` command, from the directory where your `a11y.rb` configuration file is stored:
-
-    bundle exec a11y
-
-This will pick up your `a11y.rb` configuration file and run the a11y checks on each page specified in your configuration.
-Output is printed to the console.
+We welcome contributions of ideas and code! Please refer to the
+[contributing guide](CONTRIBUTING.md).


### PR DESCRIPTION
Reviewers please! (especially helpful would be reviewers who are not so familiar with the project)

I've followed @EmmaJP's idea of splitting into two guides and leaving the readme as more of a signpost...

Probably best to ignore the diff on this one, just read this and see if it makes sense: https://github.com/cucumber-ltd/bbc-a11y/blob/better-docs/README.md

Fixes #83 and #89 
