### PR TITLE
Remove gem for terminal colours

### DIFF
--- a/bbc-a11y.gemspec
+++ b/bbc-a11y.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'capybara'
   s.add_dependency 'phantomjs'
   s.add_dependency 'poltergeist'
-  s.add_dependency 'colorize'
 
   s.add_development_dependency 'rspec',  '~> 3.0'
   s.add_development_dependency 'aruba', '~> 0.9'

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -59,7 +59,7 @@ end
 
 Then(/^I see red in the output$/) do
   all_output = all_commands.map { |c| c.output }.join("\n")
-  expect(all_output).to include('[0;31;49m✗')
+  expect(all_output).to include("\e[31m✗")
 end
 
 Then(/^I see monochrome output$/) do

--- a/lib/bbc/a11y/cli.rb
+++ b/lib/bbc/a11y/cli.rb
@@ -2,9 +2,9 @@
 require 'bbc/a11y/configuration'
 require 'bbc/a11y/linter'
 require 'bbc/a11y/runner'
+require 'bbc/a11y/string_colours'
 require 'open-uri'
 require 'capybara'
-require 'colorize'
 
 module BBC
   module A11y
@@ -46,16 +46,16 @@ module BBC
       private
 
       def red(message)
-        colorize_if_tty(message, :red)
+        colourize_if_tty(message, :red)
       end
 
       def green(message)
-        colorize_if_tty(message, :green)
+        colourize_if_tty(message, :green)
       end
 
-      def colorize_if_tty(message, colour)
+      def colourize_if_tty(message, colour)
         if tty?
-          message.colorize(colour)
+          message.send(colour)
         else
           message
         end

--- a/lib/bbc/a11y/string_colours.rb
+++ b/lib/bbc/a11y/string_colours.rb
@@ -1,0 +1,15 @@
+module BBC
+  module A11y
+    module StringColours
+      def red
+        "\e[31m#{self}\e[0m"
+      end
+
+      def green
+        "\e[32m#{self}\e[0m"
+      end
+    end
+  end
+end
+
+String.send(:include, BBC::A11y::StringColours)

--- a/spec/bbc/a11y/string_colours_spec.rb
+++ b/spec/bbc/a11y/string_colours_spec.rb
@@ -1,0 +1,13 @@
+require 'bbc/a11y/string_colours'
+
+module BBC::A11y
+  describe StringColours do
+    it "makes strings red" do
+      expect("red".red).to eql("\e[31mred\e[0m")
+    end
+
+    it "makes strings green" do
+      expect("green".green).to eql("\e[32mgreen\e[0m")
+    end
+  end
+end


### PR DESCRIPTION
Remove colorize gem, which has a GPL license... a step towards #100